### PR TITLE
リリースワークフローの改善

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.0.0)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout main
+        run: |
+          git fetch origin main
+          git checkout main
+      - name: Set up git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create tag
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+      - name: Package extension
+        run: |
+          cd extension
+          zip -r ../extension.zip .
+          cd .. # Return to repository root for following steps
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          name: ${{ github.event.inputs.version }}
+          files: extension.zip


### PR DESCRIPTION
## 概要
リリースワークフローのパッケージ作成ステップにコメントを追加し、`cd ..` が必要な理由を明記しました。

## 変更点
- パッケージ作成後にリポジトリルートへ戻る理由をコメントとして追加

## テスト
- `npm test` は `package.json` が存在しないため失敗しました。


------
https://chatgpt.com/codex/tasks/task_e_685644082fd88331800012d3a0301f2f