### PR TITLE
リリースワークフローの権限不足を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       version:
         description: 'Release version (e.g. v1.0.0)'
         required: true
+permissions:
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
## 変更内容
- `release.yml` に `permissions: contents: write` を追加し、タグ作成とリリース作成時の権限不足を解消しました。

## 動機
手動実行時に GitHub Actions がタグを push できずエラーになっていたため。

------
https://chatgpt.com/codex/tasks/task_e_685647d52a3083318fde147078246290