### PR TITLE
fix: use correct github-tag-action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Bump version and push tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package extension


### PR DESCRIPTION
## 概要
- `mathieudutour/github-tag-action` のタグを `v6` から `v6.2` に修正しました。

## テスト結果
- `npm test` は `package.json` が存在しないため実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_6856611531c88331b7e471f3d02984c7