### PR TITLE
オプション設定画面のスタイルを外部 CSS に分離

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,49 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f7fa;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+#container {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 320px;
+  box-sizing: border-box;
+}
+label {
+  display: block;
+  margin-top: 10px;
+  font-weight: bold;
+}
+input {
+  width: 100%;
+  padding: 8px;
+  margin-top: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+button {
+  width: 100%;
+  padding: 8px;
+  margin-top: 15px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #0056b3;
+}
+#status {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #28a745;
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -2,19 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; padding:10px; }
-    input { width:100%; }
-    button { margin-top:5px; }
-  </style>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <label>Slack Bot Token</label>
-  <input id="token" type="password" placeholder="xoxb-..." />
-  <label>Channel ID</label>
-  <input id="channel" type="text" placeholder="C12345678" />
-  <button id="save">Save</button>
-  <span id="status"></span>
+  <div id="container">
+    <label>Slack Bot Token</label>
+    <input id="token" type="password" placeholder="xoxb-..." />
+    <label>Channel ID</label>
+    <input id="channel" type="text" placeholder="C12345678" />
+    <button id="save">Save</button>
+    <span id="status"></span>
+  </div>
   <script src="crypto.js"></script>
   <script src="options.js"></script>
 </body>

--- a/extension/options.js
+++ b/extension/options.js
@@ -4,8 +4,10 @@ document.getElementById('save').addEventListener('click', async () => {
   const encToken = await encryptText(token);
   const encChannel = await encryptText(channel);
   chrome.storage.local.set({ token: encToken, channel: encChannel }, () => {
-    document.getElementById('status').textContent = 'Saved!';
-    setTimeout(() => { document.getElementById('status').textContent = ''; }, 1500);
+    const statusEl = document.getElementById('status');
+    statusEl.textContent = 'Saved!';
+    statusEl.style.color = '#28a745';
+    setTimeout(() => { statusEl.textContent = ''; }, 1500);
   });
 });
 


### PR DESCRIPTION
## 変更内容
- `options.html` のスタイルを `options.css` として切り出し、HTML からリンクする形式に変更

## テスト
- `npm test` を試みましたが、`package.json` が存在しないため実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_6856662461e88331b2fae117d1a6d2b5