### PR TITLE
ポップアップのデザインを刷新

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,42 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f7fa;
+  margin: 0;
+  width: 240px;
+}
+
+#container {
+  padding: 15px;
+  box-sizing: border-box;
+}
+
+textarea {
+  width: 100%;
+  height: 80px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+button {
+  width: 100%;
+  padding: 8px;
+  margin-top: 10px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+#status {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.9em;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -2,16 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; min-width:200px; padding:10px; }
-    textarea { width:100%; height:80px; }
-    button { margin-top:5px; width:100%; }
-  </style>
+  <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <textarea id="comment" placeholder="Comment"></textarea>
-  <button id="send">Post to Slack</button>
-  <div id="status"></div>
+  <div id="container">
+    <textarea id="comment" placeholder="Comment"></textarea>
+    <button id="send">Post to Slack</button>
+    <div id="status"></div>
+  </div>
   <script src="crypto.js"></script>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
## 変更点
- ポップアップ用の `popup.css` を追加しデザインを改善
- `popup.html` で新しいスタイルを読み込み、要素をコンテナで囲むように変更

## 動作確認
- 既存のテストやチェックは特にありませんでした

------
https://chatgpt.com/codex/tasks/task_e_6856681774708331b7cfcb56110993f3