### PR TITLE
release.yml の manifest 更新処理追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update manifest version
+        run: |
+          jq --arg v "${{ steps.tag.outputs.new_tag }}" '.version = $v' extension/manifest.json > extension/manifest.tmp
+          mv extension/manifest.tmp extension/manifest.json
+      - name: Commit updated manifest
+        run: |
+          git add extension/manifest.json
+          git commit -m "chore: manifest.json をタグバージョンに更新"
+          git push
       - name: Package extension
         run: |
           cd extension

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Commit updated manifest
         run: |
           git add extension/manifest.json
-          git commit -m "chore: manifest.json をタグバージョンに更新"
+          git commit -m "chore: manifest.json のバージョンを更新"
           git push
       - name: Package extension
         run: |


### PR DESCRIPTION
## 変更点
- GitHub Actions ワークフローでタグ取得後に `manifest.json` の `version` を更新しコミットするステップを追加しました

## テスト
- `act -l` を実行しましたが、Docker がないためワークフローは実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_6856d9d8d7008331a4b0f468acae0e68