### PR TITLE
Add shared credential loader

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -24,6 +24,7 @@
     <span id="status"></span>
   </div>
   <script src="crypto.js"></script>
+  <script src="storage.js"></script>
   <script src="options.js"></script>
 </body>
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -5,15 +5,15 @@
 // 保存ボタンが押された時の処理
 document.getElementById('save').addEventListener('click', async () => {
   const token = document.getElementById('token').value;
-  const channel = document.getElementById('channel').value;
-  const member = document.getElementById('member').value;
+  const channelId = document.getElementById('channel').value;
+  const memberId = document.getElementById('member').value;
 
   // ローカルストレージに保存する前に暗号化する
   const encToken = await encryptText(token);
-  const encChannel = await encryptText(channel);
-  const encMember = await encryptText(member);
+  const encChannelId = await encryptText(channelId);
+  const encMemberId = await encryptText(memberId);
 
-  chrome.storage.local.set({ token: encToken, channel: encChannel, member: encMember }, () => {
+  chrome.storage.local.set({ token: encToken, channel: encChannelId, member: encMemberId }, () => {
     const statusEl = document.getElementById('status');
     statusEl.textContent = 'Saved!';
     statusEl.style.color = '#28a745';
@@ -25,14 +25,14 @@ document.getElementById('save').addEventListener('click', async () => {
 
 document.addEventListener('DOMContentLoaded', async () => {
   // 保存済みのトークン等を読み込んでフォームに表示
-  const { token, channel, member } = await loadCredentials();
+  const { token, channelId, memberId } = await loadCredentials();
   if (token) {
     document.getElementById('token').value = token;
   }
-  if (channel) {
-    document.getElementById('channel').value = channel;
+  if (channelId) {
+    document.getElementById('channel').value = channelId;
   }
-  if (member) {
-    document.getElementById('member').value = member;
+  if (memberId) {
+    document.getElementById('member').value = memberId;
   }
 });

--- a/extension/options.js
+++ b/extension/options.js
@@ -23,29 +23,16 @@ document.getElementById('save').addEventListener('click', async () => {
   });
 });
 
-document.addEventListener('DOMContentLoaded', () => {
-  // ページ読み込み時に保存済みの値を復号して入力欄に表示する
-  chrome.storage.local.get(['token', 'channel', 'member'], async (items) => {
-    if (items.token) {
-      try {
-        document.getElementById('token').value = await decryptText(items.token);
-      } catch (e) {
-        console.error('Failed to decrypt token', e);
-      }
-    }
-    if (items.channel) {
-      try {
-        document.getElementById('channel').value = await decryptText(items.channel);
-      } catch (e) {
-        console.error('Failed to decrypt channel', e);
-      }
-    }
-    if (items.member) {
-      try {
-        document.getElementById('member').value = await decryptText(items.member);
-      } catch (e) {
-        console.error('Failed to decrypt member', e);
-      }
-    }
-  });
+document.addEventListener('DOMContentLoaded', async () => {
+  // 保存済みのトークン等を読み込んでフォームに表示
+  const { token, channel, member } = await loadCredentials();
+  if (token) {
+    document.getElementById('token').value = token;
+  }
+  if (channel) {
+    document.getElementById('channel').value = channel;
+  }
+  if (member) {
+    document.getElementById('member').value = member;
+  }
 });

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -17,6 +17,7 @@
     <div id="status"></div>
   </div>
   <script src="crypto.js"></script>
+  <script src="storage.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -10,37 +10,13 @@ document.getElementById('send').addEventListener('click', async () => {
   // 入力されたコメントを取得
   const comment = document.getElementById('comment').value;
 
-  // 保存されているトークン、チャンネル ID、メンバー ID を取得
-  chrome.storage.local.get(['token', 'channel', 'member'], async (items) => {
-    let token = null;
-    let channel = null;
-    let member = null;
-    if (items.token) {
-      try {
-        token = await decryptText(items.token);
-      } catch (e) {
-        console.error('Failed to decrypt token', e);
-      }
-    }
-    if (items.channel) {
-      try {
-        channel = await decryptText(items.channel);
-      } catch (e) {
-        console.error('Failed to decrypt channel', e);
-      }
-    }
-    if (items.member) {
-      try {
-        member = await decryptText(items.member);
-      } catch (e) {
-        console.error('Failed to decrypt member', e);
-      }
-    }
-    // 必要な情報が未設定の場合はエラー表示
-    if (!token || !channel || !member) {
-      statusEl.textContent = 'Set Slack token, channel and member in options.';
-      return;
-    }
+  // 保存されているトークン等を取得
+  const { token, channel, member } = await loadCredentials();
+  // 必要な情報が未設定の場合はエラー表示
+  if (!token || !channel || !member) {
+    statusEl.textContent = 'Set Slack token, channel and member in options.';
+    return;
+  }
     try {
       const mention = `<@${member}>`;
 
@@ -68,5 +44,4 @@ document.getElementById('send').addEventListener('click', async () => {
       console.error(e);
       statusEl.textContent = 'Failed to post.';
     }
-  });
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -11,14 +11,14 @@ document.getElementById('send').addEventListener('click', async () => {
   const comment = document.getElementById('comment').value;
 
   // 保存されているトークン等を取得
-  const { token, channel, member } = await loadCredentials();
+  const { token, channelId, memberId } = await loadCredentials();
   // 必要な情報が未設定の場合はエラー表示
-  if (!token || !channel || !member) {
+  if (!token || !channelId || !memberId) {
     statusEl.textContent = 'Set Slack token, channel and member in options.';
     return;
   }
     try {
-      const mention = `<@${member}>`;
+      const mention = `<@${memberId}>`;
 
       // Slack API へメッセージを送信
       const res = await fetch('https://slack.com/api/chat.postMessage', {
@@ -27,7 +27,7 @@ document.getElementById('send').addEventListener('click', async () => {
           'Content-Type': 'application/json; charset=utf-8',
           'Authorization': `Bearer ${token}`
         },
-        body: JSON.stringify({ channel, text: `${mention}\n${url}\n${comment}` })
+        body: JSON.stringify({ channel: channelId, text: `${mention}\n${url}\n${comment}` })
       });
       const data = await res.json();
       if (data.ok) {

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -1,0 +1,16 @@
+// Slack トークンなどを取得して復号する共通処理
+async function loadCredentials() {
+  const items = await new Promise((resolve) => {
+    chrome.storage.local.get(['token', 'channel', 'member'], resolve);
+  });
+  try {
+    const token = items.token ? await decryptText(items.token) : null;
+    const channel = items.channel ? await decryptText(items.channel) : null;
+    const member = items.member ? await decryptText(items.member) : null;
+    return { token, channel, member };
+  } catch (e) {
+    console.error('Failed to load credentials', e);
+    return { token: null, channel: null, member: null };
+  }
+}
+

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -5,12 +5,16 @@ async function loadCredentials() {
   });
   try {
     const token = items.token ? await decryptText(items.token) : null;
-    const channel = items.channel ? await decryptText(items.channel) : null;
-    const member = items.member ? await decryptText(items.member) : null;
-    return { token, channel, member };
+    const channelId = items.channel
+      ? await decryptText(items.channel)
+      : null;
+    const memberId = items.member
+      ? await decryptText(items.member)
+      : null;
+    return { token, channelId, memberId };
   } catch (e) {
     console.error('Failed to load credentials', e);
-    return { token: null, channel: null, member: null };
+    return { token: null, channelId: null, memberId: null };
   }
 }
 


### PR DESCRIPTION
## 概要
- Slack トークンなどを復号して取得する `loadCredentials()` を追加
- `options.js` と `popup.js` で共通処理を呼び出すよう修正
- HTML から `storage.js` を読み込むよう更新

## テスト
- `npm --version`
- `npm test` *(失敗: package.json が存在しないため)*

------
https://chatgpt.com/codex/tasks/task_e_6856d9d67afc83318a07f866be2fae42