### PR TITLE
chrome.storage の Promise化とエラーハンドリング改善

### DIFF
--- a/extension/crypto.js
+++ b/extension/crypto.js
@@ -10,18 +10,13 @@ function atobBytes(str) {
 
 // 生成済みの暗号鍵を取得する
 async function getStoredKey() {
-  return new Promise((resolve) => {
-    chrome.storage.local.get('encKey', (items) => {
-      resolve(items.encKey);
-    });
-  });
+  const items = await chrome.storage.local.get('encKey');
+  return items.encKey;
 }
 
 // 暗号鍵を保存する
 async function setStoredKey(key) {
-  return new Promise((resolve) => {
-    chrome.storage.local.set({ encKey: key }, resolve);
-  });
+  await chrome.storage.local.set({ encKey: key });
 }
 
 // 暗号処理に使用する鍵を取得する

--- a/extension/options.js
+++ b/extension/options.js
@@ -4,35 +4,51 @@
 
 // 保存ボタンが押された時の処理
 document.getElementById('save').addEventListener('click', async () => {
-  const token = document.getElementById('token').value;
-  const channelId = document.getElementById('channel').value;
-  const memberId = document.getElementById('member').value;
+  const statusEl = document.getElementById('status');
+  try {
+    const token = document.getElementById('token').value;
+    const channelId = document.getElementById('channel').value;
+    const memberId = document.getElementById('member').value;
 
-  // ローカルストレージに保存する前に暗号化する
-  const encToken = await encryptText(token);
-  const encChannelId = await encryptText(channelId);
-  const encMemberId = await encryptText(memberId);
+    // ローカルストレージに保存する前に暗号化する
+    const encToken = await encryptText(token);
+    const encChannelId = await encryptText(channelId);
+    const encMemberId = await encryptText(memberId);
 
-  chrome.storage.local.set({ token: encToken, channel: encChannelId, member: encMemberId }, () => {
-    const statusEl = document.getElementById('status');
+    await chrome.storage.local.set({
+      token: encToken,
+      channel: encChannelId,
+      member: encMemberId,
+    });
+
     statusEl.textContent = 'Saved!';
     statusEl.style.color = '#28a745';
-
+  } catch (e) {
+    console.error('Failed to save credentials', e);
+    statusEl.textContent = 'Failed to save.';
+    statusEl.style.color = '#dc3545';
+  } finally {
     // 保存メッセージは1.5秒後に消す
-    setTimeout(() => { statusEl.textContent = ''; }, 1500);
-  });
+    setTimeout(() => {
+      statusEl.textContent = '';
+    }, 1500);
+  }
 });
 
 document.addEventListener('DOMContentLoaded', async () => {
-  // 保存済みのトークン等を読み込んでフォームに表示
-  const { token, channelId, memberId } = await loadCredentials();
-  if (token) {
-    document.getElementById('token').value = token;
-  }
-  if (channelId) {
-    document.getElementById('channel').value = channelId;
-  }
-  if (memberId) {
-    document.getElementById('member').value = memberId;
+  try {
+    // 保存済みのトークン等を読み込んでフォームに表示
+    const { token, channelId, memberId } = await loadCredentials();
+    if (token) {
+      document.getElementById('token').value = token;
+    }
+    if (channelId) {
+      document.getElementById('channel').value = channelId;
+    }
+    if (memberId) {
+      document.getElementById('member').value = memberId;
+    }
+  } catch (e) {
+    console.error('Failed to load saved credentials', e);
   }
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -2,46 +2,46 @@
 document.getElementById('send').addEventListener('click', async () => {
   const statusEl = document.getElementById('status');
   statusEl.textContent = 'Sending...';
+  try {
+    // アクティブなタブの URL を取得
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const url = tab.url;
 
-  // アクティブなタブの URL を取得
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const url = tab.url;
+    // 入力されたコメントを取得
+    const comment = document.getElementById('comment').value;
 
-  // 入力されたコメントを取得
-  const comment = document.getElementById('comment').value;
-
-  // 保存されているトークン等を取得
-  const { token, channelId, memberId } = await loadCredentials();
-  // 必要な情報が未設定の場合はエラー表示
-  if (!token || !channelId || !memberId) {
-    statusEl.textContent = 'Set Slack token, channel and member in options.';
-    return;
-  }
-    try {
-      const mention = `<@${memberId}>`;
-
-      // Slack API へメッセージを送信
-      const res = await fetch('https://slack.com/api/chat.postMessage', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({ channel: channelId, text: `${mention}\n${url}\n${comment}` })
-      });
-      const data = await res.json();
-      if (data.ok) {
-        // 正常に投稿できた場合
-        statusEl.textContent = 'Posted!';
-        document.getElementById('comment').value = '';
-      } else {
-        // API からエラーが返ってきた場合
-        console.error('Slack API error', data);
-        statusEl.textContent = 'Failed: ' + (data.error || 'unknown error');
-      }
-    } catch (e) {
-      // ネットワークエラーなど API 通信に失敗した場合
-      console.error(e);
-      statusEl.textContent = 'Failed to post.';
+    // 保存されているトークン等を取得
+    const { token, channelId, memberId } = await loadCredentials();
+    // 必要な情報が未設定の場合はエラー表示
+    if (!token || !channelId || !memberId) {
+      statusEl.textContent = 'Set Slack token, channel and member in options.';
+      return;
     }
+
+    const mention = `<@${memberId}>`;
+
+    // Slack API へメッセージを送信
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: channelId, text: `${mention}\n${url}\n${comment}` }),
+    });
+    const data = await res.json();
+    if (data.ok) {
+      // 正常に投稿できた場合
+      statusEl.textContent = 'Posted!';
+      document.getElementById('comment').value = '';
+    } else {
+      // API からエラーが返ってきた場合
+      console.error('Slack API error', data);
+      statusEl.textContent = 'Failed: ' + (data.error || 'unknown error');
+    }
+  } catch (e) {
+    // ネットワークエラーなど API 通信に失敗した場合
+    console.error(e);
+    statusEl.textContent = 'Failed to post.';
+  }
 });

--- a/extension/storage.js
+++ b/extension/storage.js
@@ -1,16 +1,18 @@
 // Slack トークンなどを取得して復号する共通処理
 async function loadCredentials() {
-  const items = await new Promise((resolve) => {
-    chrome.storage.local.get(['token', 'channel', 'member'], resolve);
-  });
   try {
+    const items = await chrome.storage.local.get([
+      'token',
+      'channel',
+      'member',
+    ]);
+
     const token = items.token ? await decryptText(items.token) : null;
     const channelId = items.channel
       ? await decryptText(items.channel)
       : null;
-    const memberId = items.member
-      ? await decryptText(items.member)
-      : null;
+    const memberId = items.member ? await decryptText(items.member) : null;
+
     return { token, channelId, memberId };
   } catch (e) {
     console.error('Failed to load credentials', e);


### PR DESCRIPTION
## 概要
- `chrome.storage.local.get` を `await` で扱うよう修正
- 各イベントハンドラを `async/await` に合わせて整理し、エラー処理を追加
- 付随して暗号鍵の保存処理も Promise ベースへ変更

## テスト
- `node --check extension/options.js`
- `node --check extension/popup.js`
- `node --check extension/storage.js`
- `node --check extension/crypto.js`


------
https://chatgpt.com/codex/tasks/task_e_6856df78fc188331b036a6fe9a80be9c