### PR TITLE
オプション画面とポップアップを緑色基調に変更

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -1,7 +1,7 @@
 /* オプションページ全体のスタイル */
 body {
   font-family: Arial, sans-serif;
-  background-color: #f5f7fa;
+  background-color: #e8f5e9;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -11,6 +11,7 @@ body {
 /* 入力フォームを囲むコンテナ */
 #container {
   background: #fff;
+  border: 1px solid #a5d6a7;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -37,7 +38,7 @@ button {
   width: 100%;
   padding: 8px;
   margin-top: 15px;
-  background-color: #007bff;
+  background-color: #4caf50;
   color: #fff;
   border: none;
   border-radius: 4px;
@@ -45,7 +46,7 @@ button {
 }
 /* ボタンにマウスを乗せたときの色変更 */
 button:hover {
-  background-color: #0056b3;
+  background-color: #388e3c;
 }
 /* 保存完了メッセージの表示領域 */
 #status {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,7 +1,7 @@
 /* ポップアップ全体のスタイル */
 body {
   font-family: Arial, sans-serif;
-  background-color: #f5f7fa;
+  background-color: #e8f5e9;
   margin: 0;
   width: 240px;
 }
@@ -9,6 +9,7 @@ body {
 /* 入力エリアを囲むコンテナ */
 #container {
   padding: 15px;
+  border: 1px solid #a5d6a7;
   box-sizing: border-box;
 }
 
@@ -28,7 +29,7 @@ button {
   width: 100%;
   padding: 8px;
   margin-top: 10px;
-  background-color: #007bff;
+  background-color: #4caf50;
   color: #fff;
   border: none;
   border-radius: 4px;
@@ -37,7 +38,7 @@ button {
 
 /* ボタンの hover 時のスタイル */
 button:hover {
-  background-color: #0056b3;
+  background-color: #388e3c;
 }
 
 /* 投稿結果メッセージの表示領域 */


### PR DESCRIPTION
## 変更点
- オプション画面の背景とボタン色を緑系に変更
- ポップアップの背景とボタン色を緑系に変更
- 両画面のコンテナに薄い緑色の境界線を追加


------
https://chatgpt.com/codex/tasks/task_e_6856fcbf580083319ee22a483c170679