### PR TITLE
ワークフロー手動実行時に説明文を表示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release Extension
 
 on:
   workflow_dispatch:
+    description: "Chrome拡張機能をリリースするワークフローです"
 permissions:
   contents: write
 


### PR DESCRIPTION
## 概要
GitHub Actions の release ワークフローに `description` を追加しました。これにより、手動実行時にワークフローの内容がわかりやすく表示されます。

------
https://chatgpt.com/codex/tasks/task_e_6856fd9461548331aeb221cd1d52fb4c