### PR TITLE
`manifest.json` から未使用の権限を削除

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,8 +5,7 @@
   "version": "0.4.0",
   "permissions": [
     "activeTab",
-    "storage",
-    "identity"
+    "storage"
   ],
   "host_permissions": [
     "https://slack.com/*"


### PR DESCRIPTION
## 変更内容
- `permissions` 配列から `identity` を削除しました。

## 動機
- 不要な権限を取り除くことで、拡張機能の権限を最小限にするため。

------
https://chatgpt.com/codex/tasks/task_e_68578d0834748331a0b476bb336289ff