### PR TITLE
オプション画面のチャンネル一覧UIを改善

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -53,6 +53,20 @@ input {
 .remove-channel:hover {
   background-color: #d32f2f;
 }
+
+.move-up,
+.move-down {
+  background-color: #9e9e9e;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0 6px;
+}
+.move-up:hover,
+.move-down:hover {
+  background-color: #757575;
+}
 /* 保存ボタンのスタイル */
 button {
   width: 100%;
@@ -63,6 +77,11 @@ button {
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+.remove-channel,
+.move-up,
+.move-down {
+  width: auto;
 }
 /* ボタンにマウスを乗せたときの色変更 */
 button:hover {

--- a/extension/options.js
+++ b/extension/options.js
@@ -60,6 +60,30 @@ function addChannelRow(name = '', id = '') {
   idInput.className = 'channel-id';
   row.appendChild(idInput);
 
+  const upBtn = document.createElement('button');
+  upBtn.textContent = '▲';
+  upBtn.type = 'button';
+  upBtn.className = 'move-up';
+  upBtn.addEventListener('click', () => {
+    const prev = row.previousElementSibling;
+    if (prev) {
+      container.insertBefore(row, prev);
+    }
+  });
+  row.appendChild(upBtn);
+
+  const downBtn = document.createElement('button');
+  downBtn.textContent = '▼';
+  downBtn.type = 'button';
+  downBtn.className = 'move-down';
+  downBtn.addEventListener('click', () => {
+    const next = row.nextElementSibling;
+    if (next) {
+      container.insertBefore(next, row);
+    }
+  });
+  row.appendChild(downBtn);
+
   const removeBtn = document.createElement('button');
   removeBtn.textContent = 'X';
   removeBtn.type = 'button';


### PR DESCRIPTION
## 変更内容
- チャンネル入力行に上移動・下移動ボタンを追加し、登録順を並び替え可能にしました
- ボタン用のスタイルを追加し、入力行で幅が広がらないよう調整しました

## 確認事項
- テスト用スクリプトは存在しないため実行していません

------
https://chatgpt.com/codex/tasks/task_e_6857f06d8b8c83318a95a8d10d45d8a0