### PR TITLE
オプション画面の入力項目をグループ化

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -18,6 +18,16 @@ body {
   width: 320px;
   box-sizing: border-box;
 }
+fieldset {
+  border: 1px solid #a5d6a7;
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 4px;
+}
+legend {
+  font-weight: bold;
+  padding: 0 5px;
+}
 /* ラベルのスタイル */
 label {
   display: block;

--- a/extension/options.html
+++ b/extension/options.html
@@ -7,18 +7,22 @@
 <body>
   <!-- Slack の Bot トークンとチャンネル ID を設定するページ -->
   <div id="container">
-    <!-- Bot トークンの入力欄 -->
-    <label>Slack Bot Token</label>
-    <input id="token" type="password" placeholder="xoxb-..." />
+    <fieldset id="credentials">
+      <legend>Credentials</legend>
+      <!-- Bot トークンの入力欄 -->
+      <label>Slack Bot Token</label>
+      <input id="token" type="password" placeholder="xoxb-..." />
 
-    <!-- チャンネルリスト -->
-    <label>Channels</label>
-    <div id="channels"></div>
-    <button id="addChannel" type="button">Add Channel</button>
+      <!-- 自分の Slack メンバー ID の入力欄 -->
+      <label>Member ID</label>
+      <input id="member" type="text" placeholder="U12345678" />
+    </fieldset>
 
-    <!-- 自分の Slack メンバー ID の入力欄 -->
-    <label>Member ID</label>
-    <input id="member" type="text" placeholder="U12345678" />
+    <fieldset id="channel-settings">
+      <legend>Channels</legend>
+      <div id="channels"></div>
+      <button id="addChannel" type="button">Add Channel</button>
+    </fieldset>
 
     <!-- 設定を保存するボタン -->
     <button id="save">Save</button>


### PR DESCRIPTION
## 変更点
- Slack Bot Token と Member ID をまとめた `credentials` フィールドセットを追加
- チャンネル設定を独立した `channel-settings` フィールドセットに配置
- 上記に合わせたスタイルを `options.css` に追加

## 動作確認
- 本リポジトリにはテストや Lint 用の `package.json` が存在しないため、実行可能なテストはありません

------
https://chatgpt.com/codex/tasks/task_e_6857f3696f5c833196de81f6efd9602b