### PR TITLE
Add Channelボタンの色を変更

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -104,3 +104,13 @@ button:hover {
   font-size: 0.9em;
   color: #28a745;
 }
+
+/* "Add Channel" ボタンの色を反転 */
+#addChannel {
+  background-color: #fff;
+  color: #4caf50;
+  border: 1px solid #4caf50;
+}
+#addChannel:hover {
+  background-color: #c8e6c9;
+}


### PR DESCRIPTION
## 概要
オプションページの "Add Channel" ボタンが "Save" ボタンと同じ配色だったため、影響度の違いが分かりづらい状態でした。ボタンの背景色と文字色を反転させ、見た目に差を付けました。

## 変更内容
- `options.css` に `#addChannel` 用のスタイルを追加し、背景色を白、文字色を緑に変更
- `#addChannel:hover` 時の背景色を追加

## 動作確認
- 拡張機能のオプションページを開き、"Add Channel" ボタンの配色が変更されていることを確認

------
https://chatgpt.com/codex/tasks/task_e_6857f52db3488331acc9b74293690bae