### PR TITLE
チャンネル設定の初期行を表示

### DIFF
--- a/extension/options.js
+++ b/extension/options.js
@@ -104,8 +104,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (token) {
       document.getElementById('token').value = token;
     }
-    if (Array.isArray(channels)) {
+    if (Array.isArray(channels) && channels.length) {
       channels.forEach(ch => addChannelRow(ch.name, ch.id));
+    } else {
+      addChannelRow();
     }
     if (memberId) {
       document.getElementById('member').value = memberId;


### PR DESCRIPTION
## 変更内容
- オプション画面読み込み時、保存済みのチャンネルが無い場合でも空のチャンネル入力行を1つ表示するようにしました。

## 動作確認
- `options.html` をブラウザで開き、設定が空の状態でもチャンネル行が1つ表示されることを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6857f76545e8833185c8b2aaa06df8c9