### PR TITLE
オプション保存時の必須項目チェック追加

### DIFF
--- a/extension/options.js
+++ b/extension/options.js
@@ -5,20 +5,29 @@
 // 保存ボタンが押された時の処理
 document.getElementById('save').addEventListener('click', async () => {
   const statusEl = document.getElementById('status');
+  const token = document.getElementById('token').value.trim();
+  const memberId = document.getElementById('member').value.trim();
+
+  const channelRows = document.querySelectorAll('.channel-row');
+  const channels = [];
+  channelRows.forEach(row => {
+    const name = row.querySelector('.channel-name').value.trim();
+    const id = row.querySelector('.channel-id').value.trim();
+    if (name && id) {
+      channels.push({ name, id });
+    }
+  });
+
+  if (!token || !memberId || channels.length === 0) {
+    statusEl.textContent = '必須項目が未入力です。';
+    statusEl.style.color = '#dc3545';
+    setTimeout(() => {
+      statusEl.textContent = '';
+    }, 1500);
+    return;
+  }
+
   try {
-    const token = document.getElementById('token').value;
-    const memberId = document.getElementById('member').value;
-
-    const channelRows = document.querySelectorAll('.channel-row');
-    const channels = [];
-    channelRows.forEach(row => {
-      const name = row.querySelector('.channel-name').value;
-      const id = row.querySelector('.channel-id').value;
-      if (name && id) {
-        channels.push({ name, id });
-      }
-    });
-
     const encToken = await encryptText(token);
     const encMemberId = await encryptText(memberId);
     const encChannels = await encryptText(JSON.stringify(channels));


### PR DESCRIPTION
## 概要
Slack トークンやメンバー ID などの必須項目が未入力の場合にエラーメッセージを表示し、設定を保存しないようにしました。

## 変更点
- `options.js` で保存処理前に入力値を検証
- 必須項目が不足している場合は赤色のメッセージを表示して処理を中断

## 動作確認
- Chrome 拡張を読み込み、必須項目を空のまま保存ボタンを押下するとエラー表示されることを確認


------
https://chatgpt.com/codex/tasks/task_e_68595846665083318475147a6acd67ee